### PR TITLE
Add support for automatic major tag updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,3 +16,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prerelease_id: "rc"
+          update_major_tag: true

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ If you use the `dry_run` option then the workflow can also run on other pull req
 | `release_notes`   | no       | Include release notes (default: true) |
 | `release_draft`   | no       | Publish releases as draft |
 | `prerelease_draft`| no       | Publish prereleases as draft |
+| `update_major_tag`| no       | Update the major tag to point to the current release |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
         description: "Create prereleases as draft"
         required: false
         default: false
+    update_major_tag:
+        description: "Update the major tag to point to the current release, for example 1.2.0 would move the v1 tag"
+        required: false
+        default: false
 outputs:
     release_title:
         description: 'Release title'

--- a/src/pr-release.js
+++ b/src/pr-release.js
@@ -5,6 +5,7 @@ const getPR = require("./pr");
 const createReleaseData = require("./release-data");
 const createRelease = require("./create-release");
 const { addComment, addCommentReaction } = require("./comment");
+const updateMajorTag = require("./update-tag");
 
 async function run() {
   try {
@@ -55,6 +56,7 @@ async function run() {
         releaseData.body,
         prerelease
       );
+      updateMajorTag(version, commitSha);
       addComment(
         `Version [${version}](${release.html_url}) ${
           release.draft ? "drafted" : "released"

--- a/src/update-tag.js
+++ b/src/update-tag.js
@@ -1,0 +1,39 @@
+const core = require("@actions/core");
+const { GitHub, context } = require("@actions/github");
+const semver = require("semver");
+
+async function updateMajorTag(version, sha) {
+  if (core.getInput("update_major_tag") !== "true" || semver.prerelease(version)) {
+    return;
+  }
+  const token = core.getInput("github_token", { required: true });
+  const octokit = new GitHub(token);
+  const majorVersion = semver.major(version);
+  const majorTag = `v${majorVersion}`;
+  const { owner, repo } = context.repo;
+
+  try {
+    await octokit.git.getRef({
+      owner,
+      repo,
+      ref: `tags/${majorTag}`,
+    });
+    await octokit.git.updateRef({
+      owner,
+      repo,
+      sha,
+      ref: `tags/${majorTag}`,
+      force: true,
+    });
+  } catch {
+    // ref didn't exist
+    await octokit.git.createRef({
+      owner,
+      repo,
+      ref: `refs/tags/${majorTag}`,
+      sha,
+    });
+  }
+}
+
+module.exports = updateMajorTag;

--- a/tests/pr-release.test.js
+++ b/tests/pr-release.test.js
@@ -6,6 +6,7 @@ jest.mock("../src/comment");
 jest.mock("../src/create-release");
 jest.mock("../src/pr");
 jest.mock("../src/release-data");
+jest.mock("../src/update-tag");
 jest.mock("../src/version");
 
 const { addComment, addCommentReaction } = require("../src/comment");
@@ -13,6 +14,7 @@ const createRelease = require("../src/create-release");
 const getPR = require("../src/pr");
 const createReleaseData = require("../src/release-data");
 const getNextVersion = require("../src/version");
+const updateMajorTag = require("../src/update-tag")
 const run = require("../src/pr-release");
 
 beforeEach(() => {
@@ -76,6 +78,7 @@ test("Create release", async () => {
     "Release body",
     false
   );
+  expect(updateMajorTag).toHaveBeenCalledWith("1.2.0", "sha")
   expect(addComment).toHaveBeenCalledWith(
     "Version [1.2.0](URL) released! :zap:"
   );

--- a/tests/update-tag.test.js
+++ b/tests/update-tag.test.js
@@ -1,0 +1,75 @@
+jest.mock("@actions/github");
+const { GitHub, context } = require("@actions/github");
+const setInputs = require("./test-utils");
+const updateMajorTag = require("../src/update-tag");
+
+let github;
+
+beforeEach(() => {
+  context.repo = {
+    owner: "owner",
+    repo: "repo",
+  };
+  github = {
+    git: {
+      getRef: jest.fn(),
+      updateRef: jest.fn(),
+      createRef: jest.fn(),
+    },
+  };
+  GitHub.mockImplementation(() => github);
+});
+
+test("major tag is updated", async () => {
+  setInputs({ github_token: "token", update_major_tag: "true" });
+  await updateMajorTag("1.2.0", "abcd1234");
+  expect(github.git.getRef).toHaveBeenCalledWith({
+    owner: "owner",
+    ref: "tags/v1",
+    repo: "repo",
+  });
+  expect(github.git.updateRef).toHaveBeenCalledWith({
+    force: true,
+    owner: "owner",
+    ref: "tags/v1",
+    repo: "repo",
+    sha: "abcd1234",
+  });
+  expect(github.git.createRef).not.toHaveBeenCalled();
+});
+
+test("major tag is created", async () => {
+  setInputs({ github_token: "token", update_major_tag: "true" });
+  github.git.getRef.mockImplementation(() => {
+    throw new Error();
+  });
+  await updateMajorTag("1.2.0", "abcd1234");
+  expect(github.git.getRef).toHaveBeenCalledWith({
+    owner: "owner",
+    ref: "tags/v1",
+    repo: "repo",
+  });
+  expect(github.git.updateRef).not.toHaveBeenCalled();
+  expect(github.git.createRef).toHaveBeenCalledWith({
+    owner: "owner",
+    ref: "refs/tags/v1",
+    repo: "repo",
+    sha: "abcd1234",
+  });
+});
+
+test("tag is not updated for prereleases", async () => {
+  setInputs({ github_token: "token", update_major_tag: "true" });
+  await updateMajorTag("1.2.0-rc.1", "abcd1234");
+  expect(github.git.getRef).not.toHaveBeenCalled();
+  expect(github.git.updateRef).not.toHaveBeenCalled();
+  expect(github.git.createRef).not.toHaveBeenCalled();
+});
+
+test("tag is not updated when configuration is not enabled", async () => {
+  setInputs({ github_token: "token", update_major_tag: "" });
+  await updateMajorTag("1.2.0", "abcd1234");
+  expect(github.git.getRef).not.toHaveBeenCalled();
+  expect(github.git.updateRef).not.toHaveBeenCalled();
+  expect(github.git.createRef).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
The `update_major_tag` configuration can now be used to move the corresponding major tag to point to the latest version automatically.