### PR TITLE
Default to empty string if issue body is empty

### DIFF
--- a/src/release-data.js
+++ b/src/release-data.js
@@ -13,7 +13,7 @@ async function createReleaseData() {
     issue_number: number,
   });
   const title = issue.data.title;
-  let body = issue.data.body;
+  let body = issue.data.body || "";
   body = removeDependabotInstructions(body);
   if (includeReleaseNotes) {
     body = body.concat("\n\n", await createReleaseNotes());


### PR DESCRIPTION
It seems that an empty issue body now returns `null` from the API, so we need to add a default empty string that we can manipulate in that case.