### PR TITLE
ci: fix damaged lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2372,7 +2372,13 @@
       }
     },
     "node_modules/@types/node": {
-      "dev": true
+      "version": "20.12.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.5.tgz",
+      "integrity": "sha512-BD+BjQ9LS/D8ST9p5uqBxghlN+S42iuNxjsUGjeZobe/ciXzk2qb1B6IXc6AnRLS+yFJRpN2IPEHMzwspfDJNw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -5057,11 +5063,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/jest-resolve": {
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/jest-resolve-dependencies": {
       "version": "29.7.0",
@@ -10176,6 +10177,12 @@
       "engines": {
         "node": ">=14.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/unicode-emoji-modifier-base": {
       "version": "1.0.0",


### PR DESCRIPTION
Workflows were warning
```
  #8 14.82 npm WARN reify invalid or damaged lockfile detected
  #8 14.83 npm WARN reify please re-try this operation once it completes
  #8 14.83 npm WARN reify so that the damage can be corrected, or perform
  #8 14.83 npm WARN reify a fresh install with no lockfile if the problem persists.
  #8 14.83 npm WARN reify invalid or damaged lockfile detected
  #8 14.83 npm WARN reify please re-try this operation once it completes
  #8 14.83 npm WARN reify so that the damage can be corrected, or perform
  #8 14.83 npm WARN reify a fresh install with no lockfile if the problem persists.
```

So I removed the lockfile and made a clean install which recreated the lockfile seen in this PR.